### PR TITLE
Sweets/party pill

### DIFF
--- a/src/ChillpillStaking.sol
+++ b/src/ChillpillStaking.sol
@@ -15,11 +15,16 @@ pragma solidity ^0.8.15;
 /// ============ Imports ============
 
 import "./ChillToken.sol";
+import "./PartyPillStaking.sol";
 import "openzeppelin-contracts/token/ERC721/IERC721.sol";
 import "openzeppelin-contracts/token/ERC721/IERC721Receiver.sol";
 import "openzeppelin-contracts/security/ReentrancyGuard.sol";
 
-contract ChillpillStaking is ReentrancyGuard, IERC721Receiver {
+contract ChillpillStaking is
+    PartyPillStaking,
+    ReentrancyGuard,
+    IERC721Receiver
+{
     /// @notice total count of staked chillpill nfts
     uint256 public totalStaked;
     /// @notice $CHILL Token

--- a/src/ChillpillStaking.sol
+++ b/src/ChillpillStaking.sol
@@ -78,6 +78,23 @@ contract ChillpillStaking is
         _nft.safeTransferFrom(msg.sender, address(this), _tokenId);
     }
 
+    /// @notice transfer pill from staking contract to owner
+    function _unstakeTransfer(uint256 _tokenId, address _account) private {
+        if (_tokenId > partyPillStartIndex) {
+            IERC721(partyPillAddress).safeTransferFrom(
+                address(this),
+                _account,
+                _tokenId - partyPillStartIndex
+            );
+        } else {
+            IERC721(nftAddress).safeTransferFrom(
+                address(this),
+                _account,
+                _tokenId
+            );
+        }
+    }
+
     /// @notice stake you pills
     function stake(uint256[] calldata tokenIds) external nonReentrant {
         uint256 tokenId;
@@ -125,11 +142,7 @@ contract ChillpillStaking is
 
             delete vault[tokenId];
             emit NFTUnstaked(account, tokenId, block.timestamp);
-            IERC721(nftAddress).safeTransferFrom(
-                address(this),
-                account,
-                tokenId
-            );
+            _unstakeTransfer(tokenId, account);
         }
     }
 

--- a/src/ChillpillStaking.sol
+++ b/src/ChillpillStaking.sol
@@ -227,7 +227,7 @@ contract ChillpillStaking is
     function balanceOf(address account) external view returns (uint256) {
         uint256 balance = 0;
 
-        for (uint256 i = 0; i <= totalNftSupply; i++) {
+        for (uint256 i = 0; i <= totalNftSupply + 1; i++) {
             if (vault[i].owner == account) {
                 balance++;
             }
@@ -244,7 +244,7 @@ contract ChillpillStaking is
         uint256[] memory tmp = new uint256[](totalNftSupply);
 
         uint256 index = 0;
-        for (uint256 tokenId = 0; tokenId <= totalNftSupply; tokenId++) {
+        for (uint256 tokenId = 0; tokenId <= totalNftSupply + 1; tokenId++) {
             if (vault[tokenId].owner == account) {
                 tmp[index] = vault[tokenId].tokenId;
                 index++;

--- a/src/ChillpillStaking.sol
+++ b/src/ChillpillStaking.sol
@@ -167,7 +167,11 @@ contract ChillpillStaking is
             uint256 stakedAt = staked.timestamp;
             uint256 currentTime = block.timestamp;
 
-            earned += calculateEarn(stakedAt);
+            if (tokenId > partyPillStartIndex) {
+                earned += calculateEarn(stakedAt) * partyPillMultiplier;
+            } else {
+                earned += calculateEarn(stakedAt);
+            }
 
             vault[tokenId] = Stake({
                 owner: account,

--- a/src/ChillpillStaking.sol
+++ b/src/ChillpillStaking.sol
@@ -43,12 +43,18 @@ contract ChillpillStaking is
         address owner;
     }
 
+    /// @notice event fired when NFT is staked
     event NFTStaked(address owner, uint256 tokenId, uint256 value);
+    /// @notice event fired when NFT is unstaked
     event NFTUnstaked(address owner, uint256 tokenId, uint256 value);
+    /// @notice event fired when $CHILL is claimed
     event Claimed(address owner, uint256 amount);
 
+    /// @notice address of ChillRx ERC721 contract
     address public nftAddress;
+    /// @notice amount of $CHILL claimed
     uint256 public totalClaimed;
+    /// @notice total amount of ChillRx + PartyPills
     uint256 public totalNftSupply;
 
     // maps tokenId to stake
@@ -61,6 +67,7 @@ contract ChillpillStaking is
         dailyStakeRate = 8080000000000000000;
     }
 
+    /// @notice transfer pill to staking contract
     function _stakeTransfer(IERC721 _nft, uint256 _tokenId) private {
         require(_nft.ownerOf(_tokenId) == msg.sender, "not your token");
         require(
@@ -97,6 +104,7 @@ contract ChillpillStaking is
         }
     }
 
+    /// @notice cut distribution of $CHILL in half
     function halvening() internal {
         if (halveningCount < 3) {
             dailyStakeRate = dailyStakeRate / 2;
@@ -104,6 +112,7 @@ contract ChillpillStaking is
         }
     }
 
+    /// @notice unstake pills
     function _unstakeMany(address account, uint256[] calldata tokenIds)
         internal
     {
@@ -124,10 +133,12 @@ contract ChillpillStaking is
         }
     }
 
+    /// @notice claim $CHILL for self
     function claim(uint256[] calldata tokenIds) external nonReentrant {
         _claim(msg.sender, tokenIds, false);
     }
 
+    /// @notice claim $CHILL for target address
     function claimForAddress(address account, uint256[] calldata tokenIds)
         external
         nonReentrant
@@ -135,10 +146,12 @@ contract ChillpillStaking is
         _claim(account, tokenIds, false);
     }
 
+    /// @notice claim $CHILL and unstake Pill
     function unstake(uint256[] calldata tokenIds) external nonReentrant {
         _claim(msg.sender, tokenIds, true);
     }
 
+    /// @notice claim $CHILL and unstake Pill (optional)
     function _claim(
         address account,
         uint256[] calldata tokenIds,
@@ -183,12 +196,14 @@ contract ChillpillStaking is
         return dailyStakeRate / 1 days + (dailyStakeRate % 1 days);
     }
 
+    /// @notice calculate amount of unclaimed $CHILL
     function calculateEarn(uint256 stakedAt) internal view returns (uint256) {
         uint256 stakeDuration = block.timestamp - stakedAt;
         uint256 payout = stakeDuration * secondStakeRate();
         return payout;
     }
 
+    /// @notice amount of unclaimed $CHILL
     function earningInfo(address account, uint256[] calldata tokenIds)
         external
         view
@@ -244,6 +259,7 @@ contract ChillpillStaking is
         return tokens;
     }
 
+    /// @notice handles reciept of ERC721 tokens
     function onERC721Received(
         address,
         address,

--- a/src/ChillpillStaking.sol
+++ b/src/ChillpillStaking.sol
@@ -217,7 +217,11 @@ contract ChillpillStaking is
             Stake memory staked = vault[tokenId];
             require(staked.owner == account, "not an owner");
             uint256 stakedAt = staked.timestamp;
-            earned += calculateEarn(stakedAt);
+            if (tokenId > partyPillStartIndex) {
+                earned += calculateEarn(stakedAt) * partyPillMultiplier;
+            } else {
+                earned += calculateEarn(stakedAt);
+            }
         }
         return earned;
     }

--- a/src/PartyPillStaking.sol
+++ b/src/PartyPillStaking.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT LICENSE
+pragma solidity ^0.8.15;
+
+/*
+  /$$$$$$ /$$   /$$/$$$$$$/$$      /$$      /$$$$$$$ /$$$$$$/$$      /$$      
+ /$$__  $| $$  | $|_  $$_| $$     | $$     | $$__  $|_  $$_| $$     | $$      
+| $$  \__| $$  | $$ | $$ | $$     | $$     | $$  \ $$ | $$ | $$     | $$      
+| $$     | $$$$$$$$ | $$ | $$     | $$     | $$$$$$$/ | $$ | $$     | $$      
+| $$     | $$__  $$ | $$ | $$     | $$     | $$____/  | $$ | $$     | $$      
+| $$    $| $$  | $$ | $$ | $$     | $$     | $$       | $$ | $$     | $$      
+|  $$$$$$| $$  | $$/$$$$$| $$$$$$$| $$$$$$$| $$      /$$$$$| $$$$$$$| $$$$$$$$
+ \______/|__/  |__|______|________|________|__/     |______|________|________/                                                                                                                                                                                                                               
+*/
+
+/// ============ Imports ============
+contract PartyPillStaking {
+    /// @notice party pill contract address
+    address public partyPillAddress;
+    /// @notice party pill staking multiplier
+    uint8 public partyPillMultiplier;
+    /// @notice number of party pills
+    uint256 public partyPillCount;
+}

--- a/src/PartyPillStaking.sol
+++ b/src/PartyPillStaking.sol
@@ -13,11 +13,28 @@ pragma solidity ^0.8.15;
 */
 
 /// ============ Imports ============
-contract PartyPillStaking {
+import "openzeppelin-contracts/access/Ownable.sol";
+
+contract PartyPillStaking is Ownable {
     /// @notice party pill contract address
     address public partyPillAddress;
     /// @notice party pill staking multiplier
     uint8 public partyPillMultiplier;
     /// @notice number of party pills
     uint256 public partyPillCount;
+    /// @notice token Id for start of Party Pills
+    uint256 public immutable partyPillStartIndex = 10000;
+
+    constructor() Ownable() {}
+
+    /// @notice updates party pill information
+    function _updatePartyPill(
+        address _partyPillAddress,
+        uint8 _stakeMultiplier,
+        uint256 _count
+    ) internal {
+        partyPillAddress = _partyPillAddress;
+        partyPillMultiplier = _stakeMultiplier;
+        partyPillCount = _count;
+    }
 }

--- a/test/PartyPillStaking.t.sol
+++ b/test/PartyPillStaking.t.sol
@@ -102,4 +102,21 @@ contract PartyPillStakingTest is Test {
         assertEq(pp.ownerOf(1), address(cps));
         assertEq(cps.balanceOf(address(this)), 1);
     }
+
+    function testCan_stakeAllPartyPills() public {
+        setupPartyPills();
+        uint256[] memory tokensToStake = new uint256[](cps.partyPillCount());
+        for (uint256 i = 1; i <= tokensToStake.length; i++) {
+            pp.mint();
+            tokensToStake[i - 1] = offset + i;
+            assertEq(pp.ownerOf(i), address(this));
+        }
+        pp.setApprovalForAll(address(cps), true);
+        assertEq(cps.balanceOf(address(this)), 0);
+        cps.stake(tokensToStake);
+        for (uint256 i = 1; i <= tokensToStake.length; i++) {
+            assertEq(pp.ownerOf(i), address(cps));
+        }
+        assertEq(cps.balanceOf(address(this)), cps.partyPillCount());
+    }
 }

--- a/test/PartyPillStaking.t.sol
+++ b/test/PartyPillStaking.t.sol
@@ -133,4 +133,16 @@ contract PartyPillStakingTest is Test {
             24240000011612025600
         );
     }
+
+    function testCan_claim() public {
+        setupPartyPills();
+        pp.mint();
+        uint256[] memory tokensToStake = new uint256[](1);
+        tokensToStake[0] = 1 + offset;
+        pp.setApprovalForAll(address(cps), true);
+        cps.stake(tokensToStake);
+        vm.warp(block.timestamp + 1 days);
+        cps.claim(tokensToStake);
+        assertEq(ct.balanceOf(address(this)), 24240000011612025600);
+    }
 }

--- a/test/PartyPillStaking.t.sol
+++ b/test/PartyPillStaking.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 import "src/ChillpillStaking.sol";
 import "openzeppelin-contracts/token/ERC721/ERC721.sol";
 import "openzeppelin-contracts/token/ERC20/ERC20.sol";
+import "../src/lib/ChillStructs.sol";
 
 contract ChillPill is ERC721 {
     uint256 tokenId = 1;
@@ -28,24 +29,66 @@ contract PartyPills is ERC721 {
     }
 }
 
-contract PartyPillStakingTest is Test {
+contract PartyPillStakingTest is Test, ChillStructs {
     ChillpillStaking cps;
     ChillPill erc721;
     ChillToken ct;
     PartyPills pp;
     uint256 totalSupply = 9999;
     address owner = address(this);
+    uint256 offset;
 
     function setUp() public {
         erc721 = new ChillPill();
         pp = new PartyPills();
         cps = new ChillpillStaking(address(erc721), totalSupply);
         ct = cps.chillToken();
+        offset = cps.partyPillStartIndex();
     }
 
-    function testCan_initVariables() public {
+    function isInitialState() private {
         assertEq(cps.partyPillAddress(), address(0));
         assertEq(cps.partyPillMultiplier(), 0);
         assertEq(cps.partyPillCount(), 0);
+        assertEq(cps.partyPillStartIndex(), offset);
+    }
+
+    function setupPartyPills() private {
+        cps.updatePartyPill(address(pp), 3, 5000);
+    }
+
+    function testCan_initVariables() public {
+        isInitialState();
+    }
+
+    function testCan_ownable() public {
+        assertEq(cps.owner(), address(this));
+    }
+
+    function testCan_updatePartyPill() public {
+        cps.updatePartyPill(address(1), 3, 5000);
+        assertEq(cps.partyPillAddress(), address(1));
+        assertEq(cps.partyPillMultiplier(), 3);
+        assertEq(cps.partyPillCount(), 5000);
+    }
+
+    function testCan_revertNonOwnerUpdatePartyPill() public {
+        vm.prank(address(0));
+        vm.expectRevert("Ownable: caller is not the owner");
+        cps.updatePartyPill(address(1), 3, 5000);
+        isInitialState();
+    }
+
+    function testCan_stakePartyPill() public {
+        pp.mint();
+        uint256[] memory tokensToStake = new uint256[](1);
+        tokensToStake[0] = 1 + offset;
+        pp.setApprovalForAll(address(cps), true);
+        setupPartyPills();
+        assertEq(pp.ownerOf(1), address(this));
+        assertEq(cps.balanceOf(address(this)), 0);
+        cps.stake(tokensToStake);
+        assertEq(pp.ownerOf(1), address(cps));
+        assertEq(cps.balanceOf(address(this)), 1);
     }
 }

--- a/test/PartyPillStaking.t.sol
+++ b/test/PartyPillStaking.t.sol
@@ -119,4 +119,18 @@ contract PartyPillStakingTest is Test {
         }
         assertEq(cps.balanceOf(address(this)), cps.partyPillCount());
     }
+
+    function testCan_earnMultiplier() public {
+        setupPartyPills();
+        pp.mint();
+        uint256[] memory tokensToStake = new uint256[](1);
+        tokensToStake[0] = 1 + offset;
+        pp.setApprovalForAll(address(cps), true);
+        cps.stake(tokensToStake);
+        vm.warp(block.timestamp + 1 days);
+        assertEq(
+            cps.earningInfo(address(this), tokensToStake),
+            24240000011612025600
+        );
+    }
 }

--- a/test/PartyPillStaking.t.sol
+++ b/test/PartyPillStaking.t.sol
@@ -142,7 +142,24 @@ contract PartyPillStakingTest is Test {
         pp.setApprovalForAll(address(cps), true);
         cps.stake(tokensToStake);
         vm.warp(block.timestamp + 1 days);
+        assertEq(ct.balanceOf(address(this)), 0);
         cps.claim(tokensToStake);
         assertEq(ct.balanceOf(address(this)), 24240000011612025600);
+    }
+
+    function testCan_unstake() public {
+        setupPartyPills();
+        address tokenOwner = address(1);
+        vm.startPrank(tokenOwner);
+        pp.mint();
+        uint256[] memory tokensToStake = new uint256[](1);
+        tokensToStake[0] = 1 + offset;
+        pp.setApprovalForAll(address(cps), true);
+        cps.stake(tokensToStake);
+        vm.warp(block.timestamp + 1 days);
+        assertEq(ct.balanceOf(tokenOwner), 0);
+        cps.unstake(tokensToStake);
+        assertEq(ct.balanceOf(tokenOwner), 24240000011612025600);
+        assertEq(pp.balanceOf(tokenOwner), 1);
     }
 }

--- a/test/PartyPillStaking.t.sol
+++ b/test/PartyPillStaking.t.sol
@@ -54,6 +54,7 @@ contract PartyPillStakingTest is Test {
 
     function setupPartyPills() private {
         cps.updatePartyPill(address(pp), 3, 5000);
+        cps.renounceOwnership();
     }
 
     function testCan_initVariables() public {

--- a/test/PartyPillStaking.t.sol
+++ b/test/PartyPillStaking.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.15;
+
+import "forge-std/Test.sol";
+import "src/ChillpillStaking.sol";
+import "openzeppelin-contracts/token/ERC721/ERC721.sol";
+import "openzeppelin-contracts/token/ERC20/ERC20.sol";
+
+contract ChillPill is ERC721 {
+    uint256 tokenId = 1;
+
+    constructor() ERC721("CHILLPILL", "CHILLRX") {}
+
+    function mint() public {
+        _mint(msg.sender, tokenId);
+        ++tokenId;
+    }
+}
+
+contract PartyPills is ERC721 {
+    uint256 tokenId = 1;
+
+    constructor() ERC721("PARTY PILLS", "PARTY") {}
+
+    function mint() public {
+        _mint(msg.sender, tokenId);
+        ++tokenId;
+    }
+}
+
+contract PartyPillStakingTest is Test {
+    ChillpillStaking cps;
+    ChillPill erc721;
+    ChillToken ct;
+    PartyPills pp;
+    uint256 totalSupply = 9999;
+    address owner = address(this);
+
+    function setUp() public {
+        erc721 = new ChillPill();
+        pp = new PartyPills();
+        cps = new ChillpillStaking(address(erc721), totalSupply);
+        ct = cps.chillToken();
+    }
+
+    function testCan_initVariables() public {
+        assertEq(cps.partyPillAddress(), address(0));
+        assertEq(cps.partyPillMultiplier(), 0);
+        assertEq(cps.partyPillCount(), 0);
+    }
+}

--- a/test/PartyPillStaking.t.sol
+++ b/test/PartyPillStaking.t.sol
@@ -5,7 +5,6 @@ import "forge-std/Test.sol";
 import "src/ChillpillStaking.sol";
 import "openzeppelin-contracts/token/ERC721/ERC721.sol";
 import "openzeppelin-contracts/token/ERC20/ERC20.sol";
-import "../src/lib/ChillStructs.sol";
 
 contract ChillPill is ERC721 {
     uint256 tokenId = 1;
@@ -29,7 +28,7 @@ contract PartyPills is ERC721 {
     }
 }
 
-contract PartyPillStakingTest is Test, ChillStructs {
+contract PartyPillStakingTest is Test {
     ChillpillStaking cps;
     ChillPill erc721;
     ChillToken ct;
@@ -66,10 +65,22 @@ contract PartyPillStakingTest is Test, ChillStructs {
     }
 
     function testCan_updatePartyPill() public {
-        cps.updatePartyPill(address(1), 3, 5000);
+        uint256 _supply = cps.totalNftSupply();
+        uint256 _partySupply = 5000;
+        cps.updatePartyPill(address(1), 3, _partySupply);
         assertEq(cps.partyPillAddress(), address(1));
         assertEq(cps.partyPillMultiplier(), 3);
-        assertEq(cps.partyPillCount(), 5000);
+        assertEq(cps.partyPillCount(), _partySupply);
+        assertEq(cps.totalNftSupply(), _partySupply + _supply);
+    }
+
+    function testCan_updateSupplyMultipleTimes() public {
+        uint256 _supply = cps.totalNftSupply();
+        for (uint256 i = 500; i < 10000; i++) {
+            cps.updatePartyPill(address(1), 3, i);
+            assertEq(cps.partyPillCount(), i);
+            assertEq(cps.totalNftSupply(), i + _supply);
+        }
     }
 
     function testCan_revertNonOwnerUpdatePartyPill() public {


### PR DESCRIPTION
- PartyPills
- `updatePartyPill`
- `ownable`
- `stake` with Party Pills
- `earningInfo` with multiplier for Party Pills.
- `claim` for PartyPills.
- `unstake` Party Pills.
- `renounceOwnership` - burns ownership for trustlessness.